### PR TITLE
Adds arguments to `gmsh.initialize`

### DIFF
--- a/pygmsh/common/geometry.py
+++ b/pygmsh/common/geometry.py
@@ -25,8 +25,9 @@ class CommonGeometry:
     and occ.
     """
 
-    def __init__(self, env):
+    def __init__(self, env, argv=[]):
         self.env = env
+        self.argv = argv
         self._COMPOUND_ENTITIES = []
         self._RECOMBINE_ENTITIES = []
         self._EMBED_QUEUE = []
@@ -38,8 +39,8 @@ class CommonGeometry:
         self._PHYSICAL_QUEUE = []
         self._OUTWARD_NORMALS = []
 
-    def __enter__(self):
-        gmsh.initialize()
+    def __enter__(self, argv=self.argv):
+        gmsh.initialize(argv)
         gmsh.model.add("pygmsh model")
         return self
 


### PR DESCRIPTION
Allows the user to specify arguments to `gmsh.initialize`. At present `gmsh.initialize` interferes with operating system path on windows 10.
see (https://gitlab.onelab.info/gmsh/gmsh/-/issues/1142). At present the only work around is to send the '-noenv` option by calling `gmsh.initialize(['-noenv'])`.
This commit allows `pygmsh` users to specify that option when using `pygmsh.geo.Geometry()`.